### PR TITLE
Updating OAuth parameter post-breaking-change

### DIFF
--- a/workflows/create_survey.ts
+++ b/workflows/create_survey.ts
@@ -42,7 +42,9 @@ const CreateSurveyWorkflow = DefineWorkflow({
 const sheet = CreateSurveyWorkflow.addStep(
   CreateGoogleSheetFunctionDefinition,
   {
-    google_access_token_id: {},
+    google_access_token_id: {
+      credential_source: "DEVELOPER",
+    },
     title: CreateSurveyWorkflow.inputs.parent_ts,
   },
 );


### PR DESCRIPTION
This PR fixes #11.

If you have a previous existing installation of this application live anywhere (either local or deployed), you will need to, after integrating this change:

1. Re-install the app via `slack run` or `slack deploy`, depending on which app instance you want to affect. If you want to update both, you will have to run both.
2. Re-authenticate with the OAuth dance, that is, re-generate and save to Slack infra the OAuth token. Do so via the `slack external-auth add` command. Similarly, if you have both local and deployed instances of the app, you will have to do so for each.