### PR TITLE
Add a description for the `external_auth/` directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,9 @@ development and deployed apps.
 for your application on Slack infrastructure. Required scopes to use datastores
 include `datastore:write` and `datastore:read`.
 
+### `external_auth/`
+[External authentication](https://api.slack.com/automation/external-auth) enables connections to external services using OAuth2. Once connected, you can perform actions as the authorized user on these services using custom functions.
+
 ### `functions/`
 
 [Functions](https://api.slack.com/automation/functions) are reusable building

--- a/README.md
+++ b/README.md
@@ -281,7 +281,10 @@ for your application on Slack infrastructure. Required scopes to use datastores
 include `datastore:write` and `datastore:read`.
 
 ### `external_auth/`
-[External authentication](https://api.slack.com/automation/external-auth) enables connections to external services using OAuth2. Once connected, you can perform actions as the authorized user on these services using custom functions.
+
+[External authentication](https://api.slack.com/automation/external-auth)
+enables connections to external services using OAuth2. Once connected, you can
+perform actions as the authorized user on these services using custom functions.
 
 ### `functions/`
 


### PR DESCRIPTION
### Type of change (place an x in the [ ] that applies)

- [ ] New sample
- [ ] New feature
- [ ] Bug fix
- [x] Documentation

### Summary

This PR adds a section to the README to explain the `external_auth/` directory, matching the one found in [deno-timesheet-approval](https://github.com/slack-samples/deno-timesheet-approval#external_auth). A link is also added, pointing to the docs.

### Requirements

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)