### PR TITLE
Collect credentials from the end user when creating a new survey

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,17 @@ authenticated account.
 
 Keep reading on to create a link into this workflow and to connect your account!
 
+#### Collaborating with External Authentication
+
+When developing collaboratively on a deployed app, the external authentication
+tokens used for your app will be shared by all collaborators. For this reason,
+we recommend creating your Google OAuth App using an organization account so all
+collaborators can access the same account.
+
+Local development does not require a shared account, as each developer will have
+their own local app and can individually add their own external authentication
+tokens.
+
 ## Running Your Project Locally
 
 While building your app, you can see your changes appear in your workspace in

--- a/README.md
+++ b/README.md
@@ -151,41 +151,16 @@ the app locally.
 
 #### Initiate the OAuth2 Flow
 
-With your Google project created and the Client ID and secret set, you're ready
-to initiate the OAuth flow!
+With your Google project created and the Client ID and secret set, you're just
+about ready to initiate the OAuth flow!
 
-If all the right values are in place, the following command will prompt you to
-choose an app, select a provider (hint: choose the `google` one), then pick the
-Google account you want to authenticate with:
+The "Create a survey" workflow collects credentials using the
+[end user tokens](https://api.slack.com/automation/external-auth#workflow__using-end-user-tokens)
+that are gathered when this workflow is invoked. This prompts the person running
+the workflow to authenticate with Google and then performs actions as the
+authenticated account.
 
-```sh
-$ slack external-auth add
-```
-
-> :unlock: Spreadsheets generated as part of the **Create a survey** workflow
-> will be created from the account you authenticate with! To limit the users
-> that can create surveys, an **Event configurator** workflow is used.
-
-Once you've successfully connected your account, you're almost ready to create
-surveys at the press of a reaction!
-
-To complete the connection process, you need to let your app know what
-authenticated account you'll be using for specific workflows.
-
-For this specific app, only the `CreateSurvey` workflow requires a configured
-external Google account, so we can set that up with our freshly authed account.
-To do so, run:
-
-```sh
-slack external-auth select-auth
-```
-
-Select the workspace and app environment for your app, then select the
-`#/workflows/create_survey` workflow to give it access to your Google account.
-Then, select the same provider and the external account that you authenticated
-with above.
-
-At last - you're all set to survey! :sparkles:
+Keep reading on to create a link into this workflow and to connect your account!
 
 ## Running Your Project Locally
 

--- a/functions/create_prompt_trigger.ts
+++ b/functions/create_prompt_trigger.ts
@@ -1,4 +1,5 @@
 import { DefineFunction, Schema, SlackFunction } from "deno-slack-sdk/mod.ts";
+import { TriggerContextData, TriggerTypes } from "deno-slack-api/mod.ts";
 import CreateSurveyWorkflow from "../workflows/create_survey.ts";
 
 export const CreatePromptTriggerFunctionDefinition = DefineFunction({
@@ -44,7 +45,7 @@ export default SlackFunction(
     const trigger = await client.workflows.triggers.create<
       typeof CreateSurveyWorkflow.definition
     >({
-      type: "shortcut",
+      type: TriggerTypes.Shortcut,
       name: "Create a survey",
       description: "Collect feedback within a thread",
       workflow: `#/workflows/${CreateSurveyWorkflow.definition.callback_id}`,
@@ -52,7 +53,7 @@ export default SlackFunction(
         channel_id: { value: inputs.channel_id },
         parent_ts: { value: inputs.parent_ts },
         parent_url: { value: inputs.parent_url },
-        reactor_id: { value: "{{data.user_id}}" },
+        reactor_id: { value: TriggerContextData.Shortcut.user_id },
       },
       shortcut: { button_text: "Create" },
     });

--- a/functions/create_survey_trigger.ts
+++ b/functions/create_survey_trigger.ts
@@ -1,4 +1,5 @@
 import { DefineFunction, Schema, SlackFunction } from "deno-slack-sdk/mod.ts";
+import { TriggerContextData, TriggerTypes } from "deno-slack-api/mod.ts";
 import AnswerSurveyWorkflow from "../workflows/answer_survey.ts";
 
 export const CreateTriggerFunctionDefinition = DefineFunction({
@@ -42,12 +43,12 @@ export default SlackFunction(
     const trigger = await client.workflows.triggers.create<
       typeof AnswerSurveyWorkflow.definition
     >({
-      type: "shortcut",
+      type: TriggerTypes.Shortcut,
       name: "Survey your thoughts",
       description: "Share your thoughts about this post",
       workflow: `#/workflows/${AnswerSurveyWorkflow.definition.callback_id}`,
       inputs: {
-        interactivity: { value: "{{data.interactivity}}" },
+        interactivity: { value: TriggerContextData.Shortcut.interactivity },
         google_spreadsheet_id: { value: google_spreadsheet_id },
         reactor_access_token_id: { value: reactor_access_token_id },
       },

--- a/functions/triggers/prompt_survey_trigger.ts
+++ b/functions/triggers/prompt_survey_trigger.ts
@@ -8,24 +8,17 @@ import PromptSurveyWorkflow from "../../workflows/prompt_survey.ts";
  * https://api.slack.com/automation/triggers/event
  */
 const promptSurveyTrigger: Trigger<typeof PromptSurveyWorkflow.definition> = {
-  type: "event",
+  type: TriggerTypes.Event,
   name: "Survey reacji added",
   description: "Initiate survey creation by adding a clipboard reacji",
   workflow: `#/workflows/${PromptSurveyWorkflow.definition.callback_id}`,
   event: {
-    event_type: "slack#/events/reaction_added",
+    event_type: TriggerEventTypes.ReactionAdded,
     channel_ids: [""], // Channel IDs are added by the configurator workflow
     filter: {
       version: 1,
       root: {
-        operator: "AND",
-        inputs: [{
-          statement: "{{data.reaction}} == clipboard",
-        }, {
-          // User IDs are configured by the configurator workflow
-          operator: "OR",
-          inputs: [{ statement: "{{data.user_id}} == USLACKBOT" }],
-        }],
+        statement: "{{data.reaction}} == clipboard",
       },
     },
   },

--- a/functions/triggers/prompt_survey_trigger.ts
+++ b/functions/triggers/prompt_survey_trigger.ts
@@ -1,4 +1,9 @@
 import { Trigger } from "deno-slack-sdk/types.ts";
+import {
+  TriggerContextData,
+  TriggerEventTypes,
+  TriggerTypes,
+} from "deno-slack-api/mod.ts";
 import PromptSurveyWorkflow from "../../workflows/prompt_survey.ts";
 
 /**
@@ -18,14 +23,15 @@ const promptSurveyTrigger: Trigger<typeof PromptSurveyWorkflow.definition> = {
     filter: {
       version: 1,
       root: {
-        statement: "{{data.reaction}} == clipboard",
+        statement:
+          `${TriggerContextData.Event.ReactionAdded.reaction} == clipboard`,
       },
     },
   },
   inputs: {
-    channel_id: { value: "{{data.channel_id}}" },
-    parent_ts: { value: "{{data.message_ts}}" },
-    reactor_id: { value: "{{data.user_id}}" },
+    channel_id: { value: TriggerContextData.Event.ReactionAdded.channel_id },
+    parent_ts: { value: TriggerContextData.Event.ReactionAdded.message_ts },
+    reactor_id: { value: TriggerContextData.Event.ReactionAdded.user_id },
   },
 };
 

--- a/functions/triggers/remove_survey_trigger.ts
+++ b/functions/triggers/remove_survey_trigger.ts
@@ -1,25 +1,31 @@
 import { Trigger } from "deno-slack-sdk/types.ts";
+import {
+  TriggerContextData,
+  TriggerEventTypes,
+  TriggerTypes,
+} from "deno-slack-api/mod.ts";
 import RemoveSurveyWorkflow from "../../workflows/remove_survey.ts";
 
 const removeSurveyTrigger: Trigger<typeof RemoveSurveyWorkflow.definition> = {
-  type: "event",
+  type: TriggerTypes.Event,
   name: "Survey reacji removed",
   description: "Remove a survey from thread by removing the reacji",
   workflow: `#/workflows/${RemoveSurveyWorkflow.definition.callback_id}`,
   event: {
-    event_type: "slack#/events/reaction_removed",
+    event_type: TriggerEventTypes.ReactionRemoved,
     channel_ids: [""], // Channel IDs are added by the configurator workflow
     filter: {
       version: 1,
       root: {
-        statement: "{{data.reaction}} == clipboard",
+        statement:
+          `${TriggerContextData.Event.ReactionRemoved.reaction} == clipboard`,
       },
     },
   },
   inputs: {
-    channel_id: { value: "{{data.channel_id}}" },
-    parent_ts: { value: "{{data.message_ts}}" },
-    reactor_id: { value: "{{data.user_id}}" },
+    channel_id: { value: TriggerContextData.Event.ReactionRemoved.channel_id },
+    parent_ts: { value: TriggerContextData.Event.ReactionRemoved.message_ts },
+    reactor_id: { value: TriggerContextData.Event.ReactionRemoved.user_id },
   },
 };
 

--- a/functions/triggers/remove_survey_trigger.ts
+++ b/functions/triggers/remove_survey_trigger.ts
@@ -12,16 +12,7 @@ const removeSurveyTrigger: Trigger<typeof RemoveSurveyWorkflow.definition> = {
     filter: {
       version: 1,
       root: {
-        operator: "AND",
-        inputs: [{
-          statement: "{{data.reaction}} == clipboard",
-        }, {
-          operator: "OR",
-          inputs: [{
-            // User IDs are configured by the configurator workflow
-            statement: "{{data.user_id}} == USLACKBOT",
-          }],
-        }],
+        statement: "{{data.reaction}} == clipboard",
       },
     },
   },

--- a/functions/utils/trigger_operations.ts
+++ b/functions/utils/trigger_operations.ts
@@ -56,15 +56,11 @@ export async function findReactionTriggers(
  */
 export async function createReactionTriggers(
   client: SlackAPIClient,
-  filters: { channelIds: string[]; reactorIds: string[] },
+  filters: { channelIds: string[] },
 ) {
-  const { channelIds, reactorIds } = filters;
-  const reactorFilter = reactorIds.map((id) => {
-    return { statement: `{{data.user_id}} == ${id}` };
-  });
+  const { channelIds } = filters;
 
   promptSurveyTrigger.event.channel_ids = channelIds;
-  promptSurveyTrigger.event.filter.root.inputs[1].inputs = reactorFilter;
   const createPromptTrigger = await client.workflows.triggers.create(
     promptSurveyTrigger,
   );
@@ -76,7 +72,6 @@ export async function createReactionTriggers(
   }
 
   removeSurveyTrigger.event.channel_ids = channelIds;
-  removeSurveyTrigger.event.filter.root.inputs[1].inputs = reactorFilter;
   const createRemoveTrigger = await client.workflows.triggers.create(
     removeSurveyTrigger,
   );
@@ -95,17 +90,13 @@ export async function createReactionTriggers(
 export function updateReactionTriggers(
   client: SlackAPIClient,
   triggers: ReactionTriggerResponseObject[],
-  filters: { channelIds: string[]; reactorIds: string[] },
+  filters: { channelIds: string[] },
 ) {
-  const { channelIds, reactorIds } = filters;
-  const reactorFilter = reactorIds.map((id) => {
-    return { statement: `{{data.user_id}} == ${id}` };
-  });
+  const { channelIds } = filters;
 
   triggers.forEach(async (trigger) => {
     if (trigger.event_type === "slack#/events/reaction_added") {
       promptSurveyTrigger.event.channel_ids = channelIds;
-      promptSurveyTrigger.event.filter.root.inputs[1].inputs = reactorFilter;
       const updatePromptTrigger = await client.workflows.triggers
         .update({ trigger_id: trigger.id, ...promptSurveyTrigger });
       if (!updatePromptTrigger.ok) {
@@ -119,7 +110,6 @@ export function updateReactionTriggers(
     removeSurveyTrigger.event.event_type;
     if (trigger.event_type === removeSurveyTrigger.event.event_type) {
       removeSurveyTrigger.event.channel_ids = channelIds;
-      removeSurveyTrigger.event.filter.root.inputs[1].inputs = reactorFilter;
       const updateRemoveTrigger = await client.workflows.triggers
         .update({ trigger_id: trigger.id, ...removeSurveyTrigger });
       if (!updateRemoveTrigger.ok) {
@@ -139,17 +129,4 @@ export function getReactionTriggerChannelIds(
   triggers: ReactionTriggerResponseObject[],
 ): Set<string> {
   return new Set(...triggers.map((t) => t.channel_ids));
-}
-
-/**
- * getReactionTriggerSurveyorIds returns all user_ids filtered by
- * active reaction event triggers
- */
-export function getReactionTriggerSurveyorIds(
-  triggers: ReactionTriggerResponseObject[],
-): Set<string> {
-  return new Set(
-    triggers.flatMap((t) => t.filter.root.inputs[1].inputs)
-      .map((filter) => filter.statement.split(" ").pop()),
-  );
 }

--- a/workflows/answer_survey.ts
+++ b/workflows/answer_survey.ts
@@ -36,7 +36,7 @@ const AnswerSurveyWorkflow = DefineWorkflow({
 /**
  * For collecting input from users, we recommend the
  * built-in OpenForm function as a first step.
- * https://api.slack.com/automation/functions#open-a-form
+ * https://api.slack.com/reference/functions/open_form
  */
 
 // Step 1: Collect feedback in a form

--- a/workflows/create_survey.ts
+++ b/workflows/create_survey.ts
@@ -43,7 +43,7 @@ const sheet = CreateSurveyWorkflow.addStep(
   CreateGoogleSheetFunctionDefinition,
   {
     google_access_token_id: {
-      credential_source: "DEVELOPER",
+      credential_source: "END_USER",
     },
     title: CreateSurveyWorkflow.inputs.parent_ts,
   },


### PR DESCRIPTION
### Type of change

- [ ] New sample
- [x] New feature
- [ ] Bug fix
- [x] Documentation

### Summary

This PR changes the `credential_source` from `DEVELOPER` to `END_USER` to perform actions – such as creating a new spreadsheet – as the individual invoking the "Create a survey" workflow instead of from the shared developer token.

This removes the need to filter triggers by a list of approved surveyors, which makes this sample a bit more simple!

### Todo

Before reviews or merging, the following tasks remain:

- [ ] Update the demo videos in the `README.md`

### Requirements

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
